### PR TITLE
Adds REV Robotics software for FRC 2020 and REV Hub Interface for FTC

### DIFF
--- a/FRCSoftware2020.csv
+++ b/FRCSoftware2020.csv
@@ -12,6 +12,6 @@ NavX,navx-mxp.zip,https://www.kauailabs.com/public_files/navx-mxp/navx-mxp.zip,4
 VSCode-1.30.1,VSCode-win32.zip,https://vscode-update.azurewebsites.net/1.30.1/win32-archive/stable,c03410ac12386119c165a9b62c1cd3a7,true
 VSCode-1.30.1-64,VSCode-win64.zip,https://vscode-update.azurewebsites.net/1.30.1/win32-x64-archive/stable,3eca8fc696b93ae43c87cfc530b1b5d1,true
 VSCode-Cpp,VSCode-Cpp.vsix,https://github.com/Microsoft/vscode-cpptools/releases/download/0.21.0/cpptools-win32.vsix,fa79d518b034763f67c381398353d9a2,true
-REV-SPARK-MAX,SPARK-MAX-Software-All-CSATool-031219.zip,http://www.revrobotics.com/content/sw/max/SPARK-MAX-Software-All-CSATool-031219.zip,f0d0cdcdc0aded8d9001cb0d6263e0a8,true
+REV Robotics All FRC Software,REV-Robotics-Software-All-FRC-CSATool-2020-1.zip,http://www.revrobotics.com/content/sw/REV-Robotics-Software-All-FRC-CSATool-2020-1.zip,15d19153cb42bf4b5feaf50f53d750cb,true
 DotNet4.6.2,NDP462-KB3151800-x86-x64-AllOS-ENU.exe,https://download.microsoft.com/download/F/9/4/F942F07D-F26F-4F30-B4E3-EBD54FABA377/NDP462-KB3151800-x86-x64-AllOS-ENU.exe,9a5d647ee710af2b1aede329c40bbe1a,false
 Python 3.7.2,python-3.7.2.exe,https://www.python.org/ftp/python/3.7.2/python-3.7.2.exe,38156b62c0cbcb03bfddeb86e66c3a0f,false

--- a/FTCSoftware2020.csv
+++ b/FTCSoftware2020.csv
@@ -3,3 +3,4 @@ SkyStone_AndroidStudioProj,SkyStoneCode.zip,https://github.com/FIRST-Tech-Challe
 SkyStone_ManualP1,Game-Manual-P1.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-1.pdf,9de9a629118f59fcb60c48200c0398bd,false
 SkyStone_ManualP2,Game-Manual-P2.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-2.pdf,0df9ff4f2eb5b7b0d1c8e2d8d4aa0e05,false
 AndroidStudioTutorial,Android-Studio-Tutorial.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/android-studio-tutorial.pdf,347402fd505c52c03425e924b3365cb1,false
+REV Hub Interface,REVHubInterface-1.2.0.exe,http://www.revrobotics.com/content/sw/REVHubInterface-1.2.0.exe,0a9799edea3a30e9143c9e1fc1237c34,false


### PR DESCRIPTION
This includes all SPARK MAX software and docs (LabVIEW, C++, Java) the latest firmware, and the latest PC Client,

This includes the libraries for the Color Sensor V3 found in the KoP.

I also added the REV Hub Interface to the FTC list, the install includes the REV Hub firmware.