### PR TITLE
FRCSoftware2022: Add Limelight USB Driver

### DIFF
--- a/FRCSoftware2022.csv
+++ b/FRCSoftware2022.csv
@@ -17,6 +17,7 @@ DotNet4.8,NDP462-KB3151800-x86-x64-AllOS-ENU.exe,https://download.visualstudio.m
 Python 3.7.2,python-3.7.2.exe,https://www.python.org/ftp/python/3.7.2/python-3.7.2.exe,38156b62c0cbcb03bfddeb86e66c3a0f,false
 Limelight Finder Tool,LimelightFinderSetup1_0_1.exe,http://downloads.limelightvision.io/software/LimelightFinderSetup1_0_1.exe,7e3ec1ea8d1c6c78f79839a019d7c43d,false
 Limelight 2022.2.2,limelight_2022_2_2_release.zip,https://downloads.limelightvision.io/images/limelight_2022_2_2_release.zip,050DD99E167D86CD6F85AF9CBB34E3D3,true
+Limelight USB Driver,rpiboot_setup.exe,https://github.com/raspberrypi/usbboot/raw/master/win32/rpiboot_setup.exe,E6EE3C1EEB576253B500BEE1BFA2E5CA,false
 7-Zip,7z2107.exe,https://www.7-zip.org/a/7z2107-x64.exe,49839f0c227b5f9399b59f6ae94a7c7b,false
 FRC-Docs,docs-wpilib-org-en-latest.pdf,https://docs.wpilib.org/_/downloads/en/latest/pdf/,00000000000000000,false
 BalenaEtcher Portable,balenaEtcher-Portable-1.7.3.exe,https://github.com/balena-io/etcher/releases/download/v1.7.3/balenaEtcher-Portable-1.7.3.exe,003ef9497101bda77f18cd6583600c92,false


### PR DESCRIPTION
Closes #65 

I presume you were just generating the MD5 yourself from the version you downloaded at first inclusion in this list. 