### PR TITLE
For the FRC REV Hardware Client download, use a zip file that bundles the installer with data for offline use

### DIFF
--- a/FRCSoftware2023.csv
+++ b/FRCSoftware2023.csv
@@ -19,7 +19,6 @@ NavX Library,NavX-Offline-2023-0-3.zip,https://dev.studica.com/maven/release/202
 REV Hardware Client w/ bundled firmware,REV-Hardware-Client-Setup-1.5.2-with-FRC-firmware.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.2/REV-Hardware-Client-Setup-1.5.2-with-FRC-firmware.zip,8328fd1045decf42e3d55671df2720aa,true
 REVLib labVIEW API,REVLib-labVIEW-2023.1.3-1_windows_all.nipkg,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2023.1.3/REVLib-labVIEW-2023.1.3-1_windows_all.nipkg,2753d222be8661017b554bd38b4c040c,false
 REVLib Java/C++ API,REVLib-offline-v2023.1.3.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2023.1.3/REVLib-offline-v2023.1.3.zip,f72f371c9cb2f3357a9646b1e29b1dcc,true
-SPARK MAX Firmware,SPARK-MAX-FW-v1.6.3.dfu,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/sparkmax-1.6.3/SPARK-MAX-FW-v1.6.3.dfu,cdb762c0252780ab61cb6910bb6c0e79,false
 DotNet4.8,NDP462-KB3151800-x86-x64-AllOS-ENU.exe,https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe,7d2b599470e34481138444866b7e4ea6,false
 Python 3.7.2,python-3.7.2.exe,https://www.python.org/ftp/python/3.7.2/python-3.7.2.exe,38156b62c0cbcb03bfddeb86e66c3a0f,false
 Python 3.11.2,python-3.11.2-amd64.exe,https://www.python.org/ftp/python/3.11.2/python-3.11.2-amd64.exe,4331ca54d9eacdbe6e97d6ea63526e57,false

--- a/FRCSoftware2023.csv
+++ b/FRCSoftware2023.csv
@@ -16,7 +16,7 @@ RadioConfigTool Israel,FRC_Radio_Configuration_23_0_2_IL.zip,https://firstfrc.bl
 2023Manual,2023FRCGameManual.pdf,https://firstfrc.blob.core.windows.net/frc2023/Manual/2023FRCGameManual.pdf,00000000000000000,false
 NavX,navx-mxp.zip,https://www.kauailabs.com/public_files/navx-mxp/navx-mxp.zip,00000000000000000,true
 NavX Library,NavX-Offline-2023-0-3.zip,https://dev.studica.com/maven/release/2023/NavX-Offline-2023-0-3.zip,c2df1e4ad86f778a93d1c7d5facce2ee,true
-REV Hardware Client,REV-Hardware-Client-Setup-1.5.2.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.2/REV-Hardware-Client-Setup-1.5.2.exe,26b0d65fad47f565461a54675ee118ce,false
+REV Hardware Client w/ bundled firmware,REV-Hardware-Client-Setup-1.5.2-with-FRC-firmware.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.2/REV-Hardware-Client-Setup-1.5.2-with-FRC-firmware.zip,8328fd1045decf42e3d55671df2720aa,true
 REVLib labVIEW API,REVLib-labVIEW-2023.1.3-1_windows_all.nipkg,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2023.1.3/REVLib-labVIEW-2023.1.3-1_windows_all.nipkg,2753d222be8661017b554bd38b4c040c,false
 REVLib Java/C++ API,REVLib-offline-v2023.1.3.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2023.1.3/REVLib-offline-v2023.1.3.zip,f72f371c9cb2f3357a9646b1e29b1dcc,true
 SPARK MAX Firmware,SPARK-MAX-FW-v1.6.3.dfu,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/sparkmax-1.6.3/SPARK-MAX-FW-v1.6.3.dfu,cdb762c0252780ab61cb6910bb6c0e79,false

--- a/FTCSoftware2023.csv
+++ b/FTCSoftware2023.csv
@@ -5,7 +5,7 @@ PowerPlay_ManualP2,Game-Manual-P2.pdf,https://firstinspiresst01.blob.core.window
 PowerPlay_AndroidStudioGuide,Andriod-Studio-Guide.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/android-studio-guide.pdf,11f33dee77d3ae88206d4268a7d441ae,FALSE
 Robot Controller App,RevHub-8.0-FtcRobotController-release.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcRobotController-release.apk,e4fab8f3898ed3f1e2778dac04a02fd0,FALSE
 Driver Station App,RevHub-8.0-FtcDriverStation-release.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcDriverStation-release.apk,82ef0e0ffc1e8e47cc8deb45926247c4,FALSE
-REV Hardware Client,REVHardwareClient-1.4.3.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.4.3/REV-Hardware-Client-Setup-1.4.3.exe,e5087116193c934438e1ee05c5a135bf,FALSE
+REV Hardware Client,REVHardwareClient-1.5.2.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.2/REV-Hardware-Client-Setup-1.5.2.exe,26b0d65fad47f565461a54675ee118ce,FALSE
 REV Control Hub OS,RevHub-ControlHubOS-1.1.3.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/chos-1.1.3/ControlHubOS-1.1.3.zip,6eb804159f6797f915f53ae909ba0f11,FALSE
 REV Driver Hub OS,RevHub-1.2.0-DriverHubOS.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/dhos-1.2.0/DriverHubOS.zip,3a9863f48ee177d41aa6c41b36920fe8,FALSE
 REV Expansion/Control Hub Firmware,RevHub-1.8.2-REVHubFirmware_1_08_02.bin,https://www.revrobotics.com/content/sw/REVHubFirmware_1_08_02.bin,980ebc759354054c53c54eff5c82a16f,FALSE


### PR DESCRIPTION
I'm working on version 1.5.3 of the REV Hardware Client, which will support building installers that bundle all FTC and FRC software for complete offline use.

As a stopgap until that comes out, this PR replaces the 2023 FRC REV Hardware Client installer with a zip file containing that installer, the FRC firmware downloads, some metadata, and a README file that explains how to install the metadata and downloads. Without that procedure, it's not possible to use REV Hardware Client version 1.5.2 and prior to install software onto devices without connecting it to the Internet at least once.

Related changes in this PR:
* Updated the FTC REV Hardware Client to version 1.5.2.
	* For FTC, having the ability to install software through the REV Hardware Client without connecting to the Internet is somewhat less important, because all of the FTC software can be installed via other means.
* Removed the SPARK MAX firmware download
	* The SPARK MAX firmware is not intended for use outside of the REV Hardware Client, so it is covered by the new REV Hardware Client zip file.