### PR TITLE
Unmark Android OS updates as zip files

### DIFF
--- a/FTCSoftware2023.csv
+++ b/FTCSoftware2023.csv
@@ -6,6 +6,6 @@ PowerPlay_AndroidStudioGuide,Andriod-Studio-Guide.pdf,https://www.firstinspires.
 Robot Controller App,RevHub-8.0-FtcRobotController-release.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcRobotController-release.apk,e4fab8f3898ed3f1e2778dac04a02fd0,FALSE
 Driver Station App,RevHub-8.0-FtcDriverStation-release.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcDriverStation-release.apk,82ef0e0ffc1e8e47cc8deb45926247c4,FALSE
 REV Hardware Client,REVHardwareClient-1.4.3.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.4.3/REV-Hardware-Client-Setup-1.4.3.exe,e5087116193c934438e1ee05c5a135bf,FALSE
-REV Control Hub OS,RevHub-ControlHubOS-1.1.3.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/chos-1.1.3/ControlHubOS-1.1.3.zip,6eb804159f6797f915f53ae909ba0f11,TRUE
-REV Driver Hub OS,RevHub-1.2.0-DriverHubOS.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/dhos-1.2.0/DriverHubOS.zip,3a9863f48ee177d41aa6c41b36920fe8,TRUE
+REV Control Hub OS,RevHub-ControlHubOS-1.1.3.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/chos-1.1.3/ControlHubOS-1.1.3.zip,6eb804159f6797f915f53ae909ba0f11,FALSE
+REV Driver Hub OS,RevHub-1.2.0-DriverHubOS.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/dhos-1.2.0/DriverHubOS.zip,3a9863f48ee177d41aa6c41b36920fe8,FALSE
 REV Expansion/Control Hub Firmware,RevHub-1.8.2-REVHubFirmware_1_08_02.bin,https://www.revrobotics.com/content/sw/REVHubFirmware_1_08_02.bin,980ebc759354054c53c54eff5c82a16f,FALSE


### PR DESCRIPTION
While they are zip files, this tool should not be extracting them under any circumstances, as Android wants to consume them as zip files. It does appear that `ControlSystemsSoftware.UnzipFile()` doesn't get called anywhere in the current codebase, but it's a bad assumption to assume that will never change.