### PR TITLE
Update REV Hardware Client to version 1.5.3 (using program-specific offline installers), improve FTC software listings

### DIFF
--- a/FRCSoftware2023.csv
+++ b/FRCSoftware2023.csv
@@ -16,7 +16,7 @@ RadioConfigTool Israel,FRC_Radio_Configuration_23_0_2_IL.zip,https://firstfrc.bl
 2023Manual,2023FRCGameManual.pdf,https://firstfrc.blob.core.windows.net/frc2023/Manual/2023FRCGameManual.pdf,00000000000000000,false
 NavX,navx-mxp.zip,https://www.kauailabs.com/public_files/navx-mxp/navx-mxp.zip,00000000000000000,true
 NavX Library,NavX-Offline-2023-0-3.zip,https://dev.studica.com/maven/release/2023/NavX-Offline-2023-0-3.zip,c2df1e4ad86f778a93d1c7d5facce2ee,true
-REV Hardware Client w/ FRC firmware,REV-Hardware-Client-Setup-1.5.2-with-FRC-firmware.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.2/REV-Hardware-Client-1.5.2-with-FRC-firmware.zip,8328fd1045decf42e3d55671df2720aa,true
+REV Hardware Client w/ FRC firmware,REV-Hardware-Client-Setup-1.5.3-offline-FRC-2023-03-21.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.3/REV-Hardware-Client-Setup-1.5.3-offline-FRC-2023-03-21.exe,9560ece9ad9b7049f558a25f0a435b4b,false
 REVLib labVIEW API,REVLib-labVIEW-2023.1.3-1_windows_all.nipkg,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2023.1.3/REVLib-labVIEW-2023.1.3-1_windows_all.nipkg,2753d222be8661017b554bd38b4c040c,false
 REVLib Java/C++ API,REVLib-offline-v2023.1.3.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2023.1.3/REVLib-offline-v2023.1.3.zip,f72f371c9cb2f3357a9646b1e29b1dcc,true
 DotNet4.8,NDP462-KB3151800-x86-x64-AllOS-ENU.exe,https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe,7d2b599470e34481138444866b7e4ea6,false

--- a/FTCSoftware2023.csv
+++ b/FTCSoftware2023.csv
@@ -3,8 +3,8 @@ POWERPLAY Manual part 1,Game-Manual-P1.pdf,https://www.firstinspires.org/sites/d
 POWERPLAY Manual part 2,Game-Manual-P2.pdf,https://firstinspiresst01.blob.core.windows.net/first-energize-ftc/game-manual-part-2-traditional.pdf,9891b2728edf6554828847e3d8815032,FALSE
 POWERPLAY Android Studio Guide,Android-Studio-Guide.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/android-studio-guide.pdf,11f33dee77d3ae88206d4268a7d441ae,FALSE
 Android Studio project,FtcRobotController-8.1.1.zip,https://github.com/FIRST-Tech-Challenge/FtcRobotController/archive/refs/tags/v8.1.1.zip,eb5ef4927f8ceefb8c3df5f91a33dcdb,TRUE
-Robot Controller App,FtcRobotController-8.0.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcRobotController-release.apk,e4fab8f3898ed3f1e2778dac04a02fd0,FALSE
-Driver Station App,FtcDriverStation-8.0.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcDriverStation-release.apk,82ef0e0ffc1e8e47cc8deb45926247c4,FALSE
+Robot Controller App,FtcRobotController-8.1.1.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.1.1/FtcRobotController-release.apk,d9d9be18f1964754c418b8078342f5f6,FALSE
+Driver Station App,FtcDriverStation-8.1.1.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.1.1/FtcDriverStation-release.apk,a606be533afab10b14e8be6ba20805e6,FALSE
 REV Hardware Client w/ FTC software,REV-Hardware-Client-Setup-1.5.3-offline-FTC-2023-03-21.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.3/REV-Hardware-Client-Setup-1.5.3-offline-FTC-2023-03-21.exe,13955d896362aad4ce90e495d9bd859a,FALSE
 REV Control Hub OS,ControlHubOS-1.1.3.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/chos-1.1.3/ControlHubOS-1.1.3.zip,6eb804159f6797f915f53ae909ba0f11,FALSE
 REV Driver Hub OS,DriverHubOS.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/dhos-1.2.0/DriverHubOS.zip,3a9863f48ee177d41aa6c41b36920fe8,FALSE

--- a/FTCSoftware2023.csv
+++ b/FTCSoftware2023.csv
@@ -3,9 +3,9 @@ PowerPlay_AndroidStudioProj,FtcRobotController.zip,https://github.com/FIRST-Tech
 PowerPlay_ManualP1,Game-Manual-P1.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-1-traditional-events.pdf,854e41af7e21b665a7650088600b78ca,FALSE
 PowerPlay_ManualP2,Game-Manual-P2.pdf,https://firstinspiresst01.blob.core.windows.net/first-energize-ftc/game-manual-part-2-traditional.pdf,9891b2728edf6554828847e3d8815032,FALSE
 PowerPlay_AndroidStudioGuide,Andriod-Studio-Guide.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/android-studio-guide.pdf,11f33dee77d3ae88206d4268a7d441ae,FALSE
-Robot Controller App,RevHub-8.0-FtcRobotController-release.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcRobotController-release.apk,e4fab8f3898ed3f1e2778dac04a02fd0,FALSE
-Driver Station App,RevHub-8.0-FtcDriverStation-release.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcDriverStation-release.apk,82ef0e0ffc1e8e47cc8deb45926247c4,FALSE
+Robot Controller App,FtcRobotController-8.0.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcRobotController-release.apk,e4fab8f3898ed3f1e2778dac04a02fd0,FALSE
+Driver Station App,FtcDriverStation-8.0.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcDriverStation-release.apk,82ef0e0ffc1e8e47cc8deb45926247c4,FALSE
 REV Hardware Client w/ FTC software,REV-Hardware-Client-Setup-1.5.3-offline-FTC-2023-03-21.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.3/REV-Hardware-Client-Setup-1.5.3-offline-FTC-2023-03-21.exe,13955d896362aad4ce90e495d9bd859a,FALSE
-REV Control Hub OS,RevHub-ControlHubOS-1.1.3.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/chos-1.1.3/ControlHubOS-1.1.3.zip,6eb804159f6797f915f53ae909ba0f11,FALSE
-REV Driver Hub OS,RevHub-1.2.0-DriverHubOS.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/dhos-1.2.0/DriverHubOS.zip,3a9863f48ee177d41aa6c41b36920fe8,FALSE
-REV Expansion/Control Hub Firmware,RevHub-1.8.2-REVHubFirmware_1_08_02.bin,https://www.revrobotics.com/content/sw/REVHubFirmware_1_08_02.bin,980ebc759354054c53c54eff5c82a16f,FALSE
+REV Control Hub OS,ControlHubOS-1.1.3.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/chos-1.1.3/ControlHubOS-1.1.3.zip,6eb804159f6797f915f53ae909ba0f11,FALSE
+REV Driver Hub OS,DriverHubOS.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/dhos-1.2.0/DriverHubOS.zip,3a9863f48ee177d41aa6c41b36920fe8,FALSE
+REV Expansion/Control Hub Firmware,RevHubFirmware-1.8.2.bin,https://www.revrobotics.com/content/sw/REVHubFirmware_1_08_02.bin,980ebc759354054c53c54eff5c82a16f,FALSE

--- a/FTCSoftware2023.csv
+++ b/FTCSoftware2023.csv
@@ -5,7 +5,7 @@ PowerPlay_ManualP2,Game-Manual-P2.pdf,https://firstinspiresst01.blob.core.window
 PowerPlay_AndroidStudioGuide,Andriod-Studio-Guide.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/android-studio-guide.pdf,11f33dee77d3ae88206d4268a7d441ae,FALSE
 Robot Controller App,RevHub-8.0-FtcRobotController-release.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcRobotController-release.apk,e4fab8f3898ed3f1e2778dac04a02fd0,FALSE
 Driver Station App,RevHub-8.0-FtcDriverStation-release.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcDriverStation-release.apk,82ef0e0ffc1e8e47cc8deb45926247c4,FALSE
-REV Hardware Client,REVHardwareClient-1.5.2.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.2/REV-Hardware-Client-Setup-1.5.2.exe,26b0d65fad47f565461a54675ee118ce,FALSE
+REV Hardware Client w/ FTC software,REV-Hardware-Client-Setup-1.5.3-offline-FTC-2023-03-21.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.3/REV-Hardware-Client-Setup-1.5.3-offline-FTC-2023-03-21.exe,13955d896362aad4ce90e495d9bd859a,FALSE
 REV Control Hub OS,RevHub-ControlHubOS-1.1.3.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/chos-1.1.3/ControlHubOS-1.1.3.zip,6eb804159f6797f915f53ae909ba0f11,FALSE
 REV Driver Hub OS,RevHub-1.2.0-DriverHubOS.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/dhos-1.2.0/DriverHubOS.zip,3a9863f48ee177d41aa6c41b36920fe8,FALSE
 REV Expansion/Control Hub Firmware,RevHub-1.8.2-REVHubFirmware_1_08_02.bin,https://www.revrobotics.com/content/sw/REVHubFirmware_1_08_02.bin,980ebc759354054c53c54eff5c82a16f,FALSE

--- a/FTCSoftware2023.csv
+++ b/FTCSoftware2023.csv
@@ -2,7 +2,7 @@
 PowerPlay_AndroidStudioProj,FtcRobotController.zip,https://github.com/FIRST-Tech-Challenge/FtcRobotController/archive/master.zip,539d24d671e74ba41e51f0e05654fa92,TRUE
 PowerPlay_ManualP1,Game-Manual-P1.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-1-traditional-events.pdf,854e41af7e21b665a7650088600b78ca,FALSE
 PowerPlay_ManualP2,Game-Manual-P2.pdf,https://firstinspiresst01.blob.core.windows.net/first-energize-ftc/game-manual-part-2-traditional.pdf,9891b2728edf6554828847e3d8815032,FALSE
-PowerPlay_AndroidStudioGuide,Andriod-Studio-Guide.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/android-studio-guide.pdf,11f33dee77d3ae88206d4268a7d441ae,FALSE
+PowerPlay_AndroidStudioGuide,Android-Studio-Guide.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/android-studio-guide.pdf,11f33dee77d3ae88206d4268a7d441ae,FALSE
 Robot Controller App,FtcRobotController-8.0.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcRobotController-release.apk,e4fab8f3898ed3f1e2778dac04a02fd0,FALSE
 Driver Station App,FtcDriverStation-8.0.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcDriverStation-release.apk,82ef0e0ffc1e8e47cc8deb45926247c4,FALSE
 REV Hardware Client w/ FTC software,REV-Hardware-Client-Setup-1.5.3-offline-FTC-2023-03-21.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.3/REV-Hardware-Client-Setup-1.5.3-offline-FTC-2023-03-21.exe,13955d896362aad4ce90e495d9bd859a,FALSE

--- a/FTCSoftware2023.csv
+++ b/FTCSoftware2023.csv
@@ -2,7 +2,7 @@
 POWERPLAY Manual part 1,Game-Manual-P1.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-1-traditional-events.pdf,854e41af7e21b665a7650088600b78ca,FALSE
 POWERPLAY Manual part 2,Game-Manual-P2.pdf,https://firstinspiresst01.blob.core.windows.net/first-energize-ftc/game-manual-part-2-traditional.pdf,9891b2728edf6554828847e3d8815032,FALSE
 POWERPLAY Android Studio Guide,Android-Studio-Guide.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/android-studio-guide.pdf,11f33dee77d3ae88206d4268a7d441ae,FALSE
-Android Studio project,FtcRobotController.zip,https://github.com/FIRST-Tech-Challenge/FtcRobotController/archive/master.zip,539d24d671e74ba41e51f0e05654fa92,TRUE
+Android Studio project,FtcRobotController-8.1.1.zip,https://github.com/FIRST-Tech-Challenge/FtcRobotController/archive/refs/tags/v8.1.1.zip,eb5ef4927f8ceefb8c3df5f91a33dcdb,TRUE
 Robot Controller App,FtcRobotController-8.0.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcRobotController-release.apk,e4fab8f3898ed3f1e2778dac04a02fd0,FALSE
 Driver Station App,FtcDriverStation-8.0.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcDriverStation-release.apk,82ef0e0ffc1e8e47cc8deb45926247c4,FALSE
 REV Hardware Client w/ FTC software,REV-Hardware-Client-Setup-1.5.3-offline-FTC-2023-03-21.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.3/REV-Hardware-Client-Setup-1.5.3-offline-FTC-2023-03-21.exe,13955d896362aad4ce90e495d9bd859a,FALSE

--- a/FTCSoftware2023.csv
+++ b/FTCSoftware2023.csv
@@ -1,8 +1,8 @@
 #FriendlyName,FileName,URL,MD5,isZipped
-PowerPlay_AndroidStudioProj,FtcRobotController.zip,https://github.com/FIRST-Tech-Challenge/FtcRobotController/archive/master.zip,539d24d671e74ba41e51f0e05654fa92,TRUE
-PowerPlay_ManualP1,Game-Manual-P1.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-1-traditional-events.pdf,854e41af7e21b665a7650088600b78ca,FALSE
-PowerPlay_ManualP2,Game-Manual-P2.pdf,https://firstinspiresst01.blob.core.windows.net/first-energize-ftc/game-manual-part-2-traditional.pdf,9891b2728edf6554828847e3d8815032,FALSE
-PowerPlay_AndroidStudioGuide,Android-Studio-Guide.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/android-studio-guide.pdf,11f33dee77d3ae88206d4268a7d441ae,FALSE
+POWERPLAY Manual part 1,Game-Manual-P1.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-1-traditional-events.pdf,854e41af7e21b665a7650088600b78ca,FALSE
+POWERPLAY Manual part 2,Game-Manual-P2.pdf,https://firstinspiresst01.blob.core.windows.net/first-energize-ftc/game-manual-part-2-traditional.pdf,9891b2728edf6554828847e3d8815032,FALSE
+POWERPLAY Android Studio Guide,Android-Studio-Guide.pdf,https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/android-studio-guide.pdf,11f33dee77d3ae88206d4268a7d441ae,FALSE
+Android Studio project,FtcRobotController.zip,https://github.com/FIRST-Tech-Challenge/FtcRobotController/archive/master.zip,539d24d671e74ba41e51f0e05654fa92,TRUE
 Robot Controller App,FtcRobotController-8.0.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcRobotController-release.apk,e4fab8f3898ed3f1e2778dac04a02fd0,FALSE
 Driver Station App,FtcDriverStation-8.0.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.0/FtcDriverStation-release.apk,82ef0e0ffc1e8e47cc8deb45926247c4,FALSE
 REV Hardware Client w/ FTC software,REV-Hardware-Client-Setup-1.5.3-offline-FTC-2023-03-21.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.5.3/REV-Hardware-Client-Setup-1.5.3-offline-FTC-2023-03-21.exe,13955d896362aad4ce90e495d9bd859a,FALSE


### PR DESCRIPTION
The versions of the REV Hardware Client that will now be downloaded using this tool will automatically place the update files and metadata where they need to be so that all of the software for FTC/FRC is ready to go once the installer finishes.

I've also included some unrelated improvements to non-REV FTC entries to avoid merge conflicts. See the individual commit messages for details.

Without this PR merged, trying to download the FTC Android Studio project causes an uncaught exception because the md5 hash doesn't match what's at the URL, because the URL wasn't pinned to a specific version.

Relevant note: in addition to being a REV employee, I am also a member of the FTC Tech Team.