### PR TITLE
Use stable frc-docs

### DIFF
--- a/FRCSoftware2023.csv
+++ b/FRCSoftware2023.csv
@@ -27,7 +27,7 @@ Limelight 2 2023.4.0,limelight2_2023_4.zip,https://downloads.limelightvision.io/
 Limelight 3 2023.4.0,limelight3_2023_4.zip,https://downloads.limelightvision.io/images/limelight3_2023_4.zip,b590891ebe44df79de08a83b1b969776,true
 Limelight USB Driver,rpiboot_setup.exe,https://github.com/raspberrypi/usbboot/raw/master/win32/rpiboot_setup.exe,d89c6947e9b5f5f59bef272d3dbc97be,false
 7-Zip,7z2107.exe,https://www.7-zip.org/a/7z2107-x64.exe,49839f0c227b5f9399b59f6ae94a7c7b,false
-FRC-Docs,docs-wpilib-org-en-latest.pdf,https://docs.wpilib.org/_/downloads/en/latest/pdf/,00000000000000000,false
+FRC-Docs,docs-wpilib-org-en-stable.pdf,https://docs.wpilib.org/_/downloads/en/stable/pdf/,00000000000000000,false
 BalenaEtcher Portable,balenaEtcher-Portable-1.14.3.exe,https://github.com/balena-io/etcher/releases/download/v1.14.3/balenaEtcher-Portable-1.14.3.exe,a9d650b8d64720b84bd5c27ac996ec11,false
 DSLOG Reader 2.2,DSLOG-Reader.2.2.exe,https://github.com/orangelight/DSLOG-Reader/releases/download/v2.2.0/DSLOG-Reader.2.2.exe,00000000000000000,false
 System Configuration,ni-system-configuration_21.5.0_offline.iso,https://download.ni.com/support/nipkg/products/ni-s/ni-system-configuration/22.5/offline/ni-system-configuration_22.5.0_offline.iso,0f357a14f794d7feac29450d5f02315a,false


### PR DESCRIPTION
The `latest` branch of frc-docs contains documentation for new features/breaking changes during the off-season. `stable` will match `latest` in-season, but is frozen before off-season changes are made.