### PR TITLE
Various 2024 file updates/fixes

### DIFF
--- a/FRCSoftware2024.csv
+++ b/FRCSoftware2024.csv
@@ -4,31 +4,31 @@ NI-GameTools,ni-frc-2024-game-tools_24.0.1_offline.iso,https://download.ni.com/s
 NI-CompactRIO Driver,ni-compactrio-device-drivers_24.0.0.49260-0+f108_offline.iso,https://download.ni.com/support/nipkg/products/ni-c/ni-compactrio-device-drivers/24.0/offline/ni-compactrio-device-drivers_24.0.0.49260-0+f108_offline.iso,a76eef4d5d81d9f01a1c2ea860ba170a,FALSE
 NI-System Configuration,ni-system-configuration_24.0.0_offline.iso,https://download.ni.com/support/nipkg/products/ni-s/ni-system-configuration/24.0/offline/ni-system-configuration_24.0.0_offline.iso,952156ec99ed9b15fb38be981ee0600f,FALSE
 WPILibInstaller_Windows64,WPILib_Windows-2024.3.1.iso,https://packages.wpilib.workers.dev/installer/v2024.3.1/Win64/WPILib_Windows-2024.3.1.iso,781408b02146fde5a8275f31bd55a23c,FALSE
+WPILib VSCode Windows Archive,VSCode-1.85.1-Windows.zip,https://update.code.visualstudio.com/1.85.1/win32-x64-archive/stable,5621fc9203a0468f9270e2151ac2cdea,TRUE
 Password,2024Password.txt,https://raw.githubusercontent.com/JamieSinn/CSA-USB-Tool/master/2024Password.txt,f7226fa16bbca941473c41beacf2dba4,FALSE
-CTRE Phoenix Windows Installer,CTRE_Phoenix_Framework_v5.30.4.2.exe,https://github.com/CrossTheRoadElec/Phoenix-Releases/releases/download/v5.30.4.2/CTRE_Phoenix_Framework_v5.30.4.2.exe,3a2ae2e2dcece40732f88e4b7baafd17,FALSE
 CTRE Latest Firmware,ctr-device-firmware.zip,https://github.com/CrossTheRoadElec/Phoenix-Releases/raw/master/ctr-device-firmware.zip,00000000000000000,TRUE
-CTRE Tuner X Offline,Tuner_X_v2023.2.2.0_for_Offline_Install.zip,https://github.com/CrossTheRoadElec/Phoenix-Releases/releases/download/v24.2.0/Phoenix-Offline_v24.2.0.exe,4309bff08b61bc6bfb36e946ed1cf6d7,TRUE
-CTRE Linux Offline,CTRE_Phoenix_FRC_Linux_5.30.4.zip,https://github.com/CrossTheRoadElec/Phoenix-Releases/releases/download/v5.30.4.2/CTRE_Phoenix_FRC_Linux_5.30.4.zip,DF58D947801F4FC3A23128E5EE316E4E,TRUE
-CTRE macOS Offline,CTRE_Phoenix_FRC_macOS_5.30.4.zip,https://github.com/CrossTheRoadElec/Phoenix-Releases/releases/download/v5.30.4.2/CTRE_Phoenix_FRC_macOS_5.30.4.zip,BC3A52E7A1DAE5284EA18327B754F0AD,TRUE
+CTRE Pheonix Windows Installer,Phoenix-Offline_v24.2.0.exe,https://github.com/CrossTheRoadElec/Phoenix-Releases/releases/download/v24.2.0/Phoenix-Offline_v24.2.0.exe,7def85aee10824fba32f0b1b86b7414c,FALSE
 CTRE Phoenix v5 Docs,v5-docs-ctr-electronics-com-en-stable.pdf,https://v5.docs.ctr-electronics.com/_/downloads/en/stable/pdf/,00000000000000000,FALSE
-CTRE Phoenix Pro Docs,pro-docs-ctr-electronics-com-en-stable.pdf,https://pro.docs.ctr-electronics.com/_/downloads/en/stable/pdf/,00000000000000000,FALSE
+CTRE Phoenix 6 Docs,pro-docs-ctr-electronics-com-en-stable.pdf,https://v6.docs.ctr-electronics.com/_/downloads/en/stable/pdf/,00000000000000000,FALSE
 RadioConfigTool,FRC_Radio_Configuration_24_0_1.zip,https://firstfrc.blob.core.windows.net/frc2024/Radio/FRC_Radio_Configuration_24_0_1.zip,b5b755f4947e79e43bc93dae281ba3e2,TRUE
 RadioConfigTool Israel,FRC_Radio_Configuration_24_0_1_IL.zip,https://firstfrc.blob.core.windows.net/frc2024/Radio/FRC_Radio_Configuration_24_0_1_IL.zip,4309bff08b61bc6bfb36e946ed1cf6d7,TRUE
-2023Manual,2024GameManual.pdf,https://firstfrc.blob.core.windows.net/frc2024/Manual/2024GameManual.pdf,00000000000000000,FALSE
+2024Manual,2024GameManual.pdf,https://firstfrc.blob.core.windows.net/frc2024/Manual/2024GameManual.pdf,00000000000000000,FALSE
 NavX,navx-mxp.zip,https://www.kauailabs.com/public_files/navx-mxp/navx-mxp.zip,00000000000000000,TRUE
 NavX Library,NavX-Offline-2023-0-3.zip,https://dev.studica.com/maven/release/2023/NavX-Offline-2023-0-3.zip,c2df1e4ad86f778a93d1c7d5facce2ee,TRUE
 REV Hardware Client w/ FRC firmware,REV-Hardware-Client-Setup-1.6.4-offline-FRC-2024-02-17.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.6.4/REV-Hardware-Client-Setup-1.6.4-offline-FRC-2024-02-17.exe,c03a4fcf1baafef68bf40db626125aee,FALSE
 REVLib LabVIEW API,REVLib-labVIEW-2024.2.0-0_windows_all.nipkg,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2024.2.0/REVLib-labVIEW-2024.2.0-0_windows_all.nipkg,9dcb8aa105fcf306c2ae96d7c286cafe,FALSE
 REVLib Java/C++ API,REVLib-offline-v2024.2.1.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2024.2.1/REVLib-offline-v2024.2.1.zip,443e18f01b7e5d1e500ab6e51e55ef32,TRUE
+ReduxLib Offline,ReduxLib-offline-v2024.1.1.zip,https://frcsdk.reduxrobotics.com/offline/ReduxLib-offline-v2024.1.1.zip,5a30ebbfb3780f7edcd582821b33437b,TRUE
+Redux Alchemist,Redux-Alchemist-Setup-2023.0.1.exe,https://github.com/Redux-Robotics/Alchemist/releases/download/v2023.0.1/Redux-Alchemist-Setup-2023.0.1.exe,a67befd08fd3473f0eca4e91a43e4d42,FALSE
 DotNet4.8,NDP462-KB3151800-x86-x64-AllOS-ENU.exe,https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe,7d2b599470e34481138444866b7e4ea6,FALSE
 Python 3.7.2,python-3.7.2.exe,https://www.python.org/ftp/python/3.7.2/python-3.7.2.exe,38156b62c0cbcb03bfddeb86e66c3a0f,FALSE
 Python 3.11.2,python-3.11.2-amd64.exe,https://www.python.org/ftp/python/3.11.2/python-3.11.2-amd64.exe,4331ca54d9eacdbe6e97d6ea63526e57,FALSE
 Limelight Hardware Manager,LimelightHardwareManagerSetup1_3_0.exe,https://downloads.limelightvision.io/software/LimelightHardwareManagerSetup1_3_0.exe,17bcbd5c25ccf8ff11c5ed63bcc532b1,FALSE
-Limelight v1 v2 v2+ 2024.0.0,limelight2_2024_0.zip,https://downloads.limelightvision.io/images/limelight2_2024_0.zip,ebc70ebf106f1ae5b06dc3755fabd9ec,TRUE
-Limelight v3 2023.4.0,limelight3_2024_0.zip,https://downloads.limelightvision.io/images/limelight3_2024_0.zip,b590891ebe44df79de08a83b1b969776,TRUE
+Limelight v1 v2 v2+ 2024.0.0,limelight2_2024_0.zip,https://downloads.limelightvision.io/images/limelight2_2024_0.zip,6704f7d3b848d2a777e6f0be2e1b4c43,TRUE
+Limelight v3 2024.0.0,limelight3_2024_0.zip,https://downloads.limelightvision.io/images/limelight3_2024_0.zip,874035410b05a17e798718781c0c6a81,TRUE
 Limelight USB Driver,rpiboot_setup.exe,https://github.com/raspberrypi/usbboot/raw/master/win32/rpiboot_setup.exe,f292c52cffaf65e16fb7aead6abe7ddf,FALSE
 7-Zip,7z2301-x64.exe,https://www.7-zip.org/a/7z2301-x64.exe,e5788b13546156281bf0a4b38bdd0901,FALSE
 FRC-Docs,docs-wpilib-org-en-stable.pdf,https://docs.wpilib.org/_/downloads/en/stable/pdf/,00000000000000000,FALSE
-BalenaEtcher Portable,balenaEtcher-Portable-1.14.3.exe,https://github.com/balena-io/etcher/releases/download/v1.14.3/balenaEtcher-Portable-1.14.3.exe,a9d650b8d64720b84bd5c27ac996ec11,FALSE
-DSLOG Reader 2.2,DSLOG-Reader.2.2.exe,https://github.com/orangelight/DSLOG-Reader/releases/download/v2.2.3/DSLOG-Reader.2.2.exe,00000000000000000,FALSE
+BalenaEtcher Portable,balenaEtcher-Portable-1.18.11.exe,https://github.com/balena-io/etcher/releases/download/v1.18.11/balenaEtcher-Portable-1.18.11.exe,e2b9c834b2874da01e8615aef8395265,FALSE
+DSLOG Reader 2.2,DSLOG-Reader.2.2.exe,https://github.com/orangelight/DSLOG-Reader/releases/download/v2.2.3/DSLOG-Reader.2.2.exe,46c9f05169adee3f589e6ab52960f357,FALSE
 VisualVM,visualvm_217.zip,https://github.com/oracle/visualvm/releases/download/2.1.7/visualvm_217.zip,61eb68ae1b3946103967331cc496fb64,TRUE

--- a/FRCSoftware2024.csv
+++ b/FRCSoftware2024.csv
@@ -7,7 +7,7 @@ WPILibInstaller_Windows64,WPILib_Windows-2024.3.1.iso,https://packages.wpilib.wo
 WPILib VSCode Windows Archive,VSCode-1.85.1-Windows.zip,https://update.code.visualstudio.com/1.85.1/win32-x64-archive/stable,5621fc9203a0468f9270e2151ac2cdea,TRUE
 Password,2024Password.txt,https://raw.githubusercontent.com/JamieSinn/CSA-USB-Tool/master/2024Password.txt,f7226fa16bbca941473c41beacf2dba4,FALSE
 CTRE Latest Firmware,ctr-device-firmware.zip,https://github.com/CrossTheRoadElec/Phoenix-Releases/raw/master/ctr-device-firmware.zip,00000000000000000,TRUE
-CTRE Pheonix Windows Installer,Phoenix-Offline_v24.2.0.exe,https://github.com/CrossTheRoadElec/Phoenix-Releases/releases/download/v24.2.0/Phoenix-Offline_v24.2.0.exe,7def85aee10824fba32f0b1b86b7414c,FALSE
+CTRE Phoenix Windows Installer,Phoenix-Offline_v24.2.0.exe,https://github.com/CrossTheRoadElec/Phoenix-Releases/releases/download/v24.2.0/Phoenix-Offline_v24.2.0.exe,7def85aee10824fba32f0b1b86b7414c,FALSE
 CTRE Phoenix v5 Docs,v5-docs-ctr-electronics-com-en-stable.pdf,https://v5.docs.ctr-electronics.com/_/downloads/en/stable/pdf/,00000000000000000,FALSE
 CTRE Phoenix 6 Docs,pro-docs-ctr-electronics-com-en-stable.pdf,https://v6.docs.ctr-electronics.com/_/downloads/en/stable/pdf/,00000000000000000,FALSE
 RadioConfigTool,FRC_Radio_Configuration_24_0_1.zip,https://firstfrc.blob.core.windows.net/frc2024/Radio/FRC_Radio_Configuration_24_0_1.zip,b5b755f4947e79e43bc93dae281ba3e2,TRUE


### PR DESCRIPTION
- Add offline vscode zip for windows (enabled by https://github.com/wpilibsuite/WPILibInstaller-Avalonia/pull/342)
- Remove old phoenix installers
- Rename "CTRE Tuner X Offline" To "CTRE Phoenix Windows Installer" (the installer installs both v5 and 6 libraries as well as Tuner X)
- Add ReduxLib and Alchemist
- Update balenaEtcher
- Fix a few missed filename updates
- Fix some incorrect md5s