### PR TITLE
Update REV Hardware Client to 1.6.5

### DIFF
--- a/FRCSoftware2024.csv
+++ b/FRCSoftware2024.csv
@@ -14,7 +14,7 @@ RadioConfigTool,FRC_Radio_Configuration_24_0_1.zip,https://firstfrc.blob.core.wi
 RadioConfigTool Israel,FRC_Radio_Configuration_24_0_1_IL.zip,https://firstfrc.blob.core.windows.net/frc2024/Radio/FRC_Radio_Configuration_24_0_1_IL.zip,4309bff08b61bc6bfb36e946ed1cf6d7,TRUE
 2024Manual,2024GameManual.pdf,https://firstfrc.blob.core.windows.net/frc2024/Manual/2024GameManual.pdf,00000000000000000,FALSE
 NavX,navx-mxp.zip,https://www.kauailabs.com/public_files/navx-mxp/navx-mxp.zip,00000000000000000,TRUE
-REV Hardware Client w/ FRC firmware,REV-Hardware-Client-Setup-1.6.5-offline-FRC-2024-04-12.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.6.5/REV-Hardware-Client-Setup-1.6.5-offline-FRC-2024-04-12.exe,9aa88debcf7f6980518f908925d7aa65,FALSE
+REV Hardware Client w/ FRC firmware,REV-Hardware-Client-Setup-1.6.6-offline-FRC-2024-04-12.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.6.6/REV-Hardware-Client-Setup-1.6.6-offline-FRC-2024-04-12.exe,3655ffb3176637e9fb1e061d810c1a00,FALSE
 REVLib LabVIEW API,REVLib-labVIEW-2024.2.0-0_windows_all.nipkg,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2024.2.0/REVLib-labVIEW-2024.2.0-0_windows_all.nipkg,9dcb8aa105fcf306c2ae96d7c286cafe,FALSE
 REVLib Java/C++ API,REVLib-offline-v2024.2.4.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2024.2.4/REVLib-offline-v2024.2.4.zip,5bedfe205eb3b72c75bc81c87e9dc808,TRUE
 ReduxLib Offline,ReduxLib-offline-v2024.1.1.zip,https://frcsdk.reduxrobotics.com/offline/ReduxLib-offline-v2024.1.1.zip,5a30ebbfb3780f7edcd582821b33437b,TRUE

--- a/FRCSoftware2024.csv
+++ b/FRCSoftware2024.csv
@@ -14,7 +14,7 @@ RadioConfigTool,FRC_Radio_Configuration_24_0_1.zip,https://firstfrc.blob.core.wi
 RadioConfigTool Israel,FRC_Radio_Configuration_24_0_1_IL.zip,https://firstfrc.blob.core.windows.net/frc2024/Radio/FRC_Radio_Configuration_24_0_1_IL.zip,4309bff08b61bc6bfb36e946ed1cf6d7,TRUE
 2024Manual,2024GameManual.pdf,https://firstfrc.blob.core.windows.net/frc2024/Manual/2024GameManual.pdf,00000000000000000,FALSE
 NavX,navx-mxp.zip,https://www.kauailabs.com/public_files/navx-mxp/navx-mxp.zip,00000000000000000,TRUE
-REV Hardware Client w/ FRC firmware,REV-Hardware-Client-Setup-1.6.4-offline-FRC-2024-04-03.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.6.4/REV-Hardware-Client-Setup-1.6.4-offline-FRC-2024-04-03.exe,334f9a6103ed7db99ab311a921e6c4ba,FALSE
+REV Hardware Client w/ FRC firmware,REV-Hardware-Client-Setup-1.6.5-offline-FRC-2024-04-12.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.6.5/REV-Hardware-Client-Setup-1.6.5-offline-FRC-2024-04-12.exe,9aa88debcf7f6980518f908925d7aa65,FALSE
 REVLib LabVIEW API,REVLib-labVIEW-2024.2.0-0_windows_all.nipkg,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2024.2.0/REVLib-labVIEW-2024.2.0-0_windows_all.nipkg,9dcb8aa105fcf306c2ae96d7c286cafe,FALSE
 REVLib Java/C++ API,REVLib-offline-v2024.2.4.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2024.2.4/REVLib-offline-v2024.2.4.zip,5bedfe205eb3b72c75bc81c87e9dc808,TRUE
 ReduxLib Offline,ReduxLib-offline-v2024.1.1.zip,https://frcsdk.reduxrobotics.com/offline/ReduxLib-offline-v2024.1.1.zip,5a30ebbfb3780f7edcd582821b33437b,TRUE

--- a/FTCSoftware2023.csv
+++ b/FTCSoftware2023.csv
@@ -5,7 +5,7 @@ POWERPLAY Android Studio Guide,Android-Studio-Guide.pdf,https://www.firstinspire
 Android Studio project,FtcRobotController-8.1.1.zip,https://github.com/FIRST-Tech-Challenge/FtcRobotController/archive/refs/tags/v8.1.1.zip,eb5ef4927f8ceefb8c3df5f91a33dcdb,TRUE
 Robot Controller App,FtcRobotController-8.1.1.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.1.1/FtcRobotController-release.apk,d9d9be18f1964754c418b8078342f5f6,FALSE
 Driver Station App,FtcDriverStation-8.1.1.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.1.1/FtcDriverStation-release.apk,a606be533afab10b14e8be6ba20805e6,FALSE
-REV Hardware Client w/ FTC software, REV-Hardware-Client-Setup-1.6.4-offline-FTC-2024-04-03.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.6.4/REV-Hardware-Client-Setup-1.6.4-offline-FTC-2024-04-03.exe,078c05ef9b7de8de2836f61e6af4752b,FALSE
+REV Hardware Client w/ FTC software, REV-Hardware-Client-Setup-1.6.5-offline-FTC-2024-04-12.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.6.5/REV-Hardware-Client-Setup-1.6.5-offline-FTC-2024-04-12.exe,3b4d9852c9d60e82947f3e2aba796adc,FALSE
 REV Control Hub OS,ControlHubOS-1.1.3.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/chos-1.1.3/ControlHubOS-1.1.3.zip,6eb804159f6797f915f53ae909ba0f11,FALSE
 REV Driver Hub OS,DriverHubOS.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/dhos-1.2.0/DriverHubOS.zip,3a9863f48ee177d41aa6c41b36920fe8,FALSE
 REV Expansion/Control Hub Firmware,RevHubFirmware-1.8.2.bin,https://www.revrobotics.com/content/sw/REVHubFirmware_1_08_02.bin,980ebc759354054c53c54eff5c82a16f,FALSE

--- a/FTCSoftware2023.csv
+++ b/FTCSoftware2023.csv
@@ -5,7 +5,7 @@ POWERPLAY Android Studio Guide,Android-Studio-Guide.pdf,https://www.firstinspire
 Android Studio project,FtcRobotController-8.1.1.zip,https://github.com/FIRST-Tech-Challenge/FtcRobotController/archive/refs/tags/v8.1.1.zip,eb5ef4927f8ceefb8c3df5f91a33dcdb,TRUE
 Robot Controller App,FtcRobotController-8.1.1.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.1.1/FtcRobotController-release.apk,d9d9be18f1964754c418b8078342f5f6,FALSE
 Driver Station App,FtcDriverStation-8.1.1.apk,https://github.com/FIRST-Tech-Challenge/FtcRobotController/releases/download/v8.1.1/FtcDriverStation-release.apk,a606be533afab10b14e8be6ba20805e6,FALSE
-REV Hardware Client w/ FTC software, REV-Hardware-Client-Setup-1.6.5-offline-FTC-2024-04-12.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.6.5/REV-Hardware-Client-Setup-1.6.5-offline-FTC-2024-04-12.exe,3b4d9852c9d60e82947f3e2aba796adc,FALSE
+REV Hardware Client w/ FTC software, REV-Hardware-Client-Setup-1.6.6-offline-FTC-2024-04-12.exe,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/rhc-1.6.6/REV-Hardware-Client-Setup-1.6.6-offline-FTC-2024-04-12.exe,8505df9d2bf8b773340c0fcaeda56e24,FALSE
 REV Control Hub OS,ControlHubOS-1.1.3.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/chos-1.1.3/ControlHubOS-1.1.3.zip,6eb804159f6797f915f53ae909ba0f11,FALSE
 REV Driver Hub OS,DriverHubOS.zip,https://github.com/REVrobotics/REV-Software-Binaries/releases/download/dhos-1.2.0/DriverHubOS.zip,3a9863f48ee177d41aa6c41b36920fe8,FALSE
 REV Expansion/Control Hub Firmware,RevHubFirmware-1.8.2.bin,https://www.revrobotics.com/content/sw/REVHubFirmware_1_08_02.bin,980ebc759354054c53c54eff5c82a16f,FALSE


### PR DESCRIPTION
This release has lots of high-impact bugfixes: https://github.com/REVrobotics/REV-Software-Binaries/releases/tag/rhc-1.6.5