### PR TITLE
Hook up progress bars, fix crash if cancelling download folder selection

### DIFF
--- a/CSAUSBTool.CrossPlatform/Models/ControlSystemSoftware.cs
+++ b/CSAUSBTool.CrossPlatform/Models/ControlSystemSoftware.cs
@@ -24,7 +24,13 @@ namespace CSAUSBTool.CrossPlatform.Models
         public string Uri { get; set; }
         public string? Hash { get; set; }
         public string Platform { get; set; }
-        public double DownloadProgress { get; set; }
+
+        private double _DownloadProgress;
+        public double DownloadProgress
+        {
+            get => _DownloadProgress;
+            set => this.RaiseAndSetIfChanged(ref _DownloadProgress, value);
+        }
 
         public ControlSystemSoftware()
         {
@@ -51,6 +57,7 @@ namespace CSAUSBTool.CrossPlatform.Models
                         var currentHash = CalculateMD5(existingFile);
                         if (currentHash == Hash)
                         {
+                            DownloadProgress = 100;
                             return;
                         }
 

--- a/CSAUSBTool.CrossPlatform/Views/ControlSystemSoftwareGroupView.axaml.cs
+++ b/CSAUSBTool.CrossPlatform/Views/ControlSystemSoftwareGroupView.axaml.cs
@@ -45,12 +45,15 @@ namespace CSAUSBTool.CrossPlatform.Views
                 AllowMultiple = false
             });
 
+            if (folder == null || folder.Count < 1) return;
+            var downloadPath = folder[0].Path.ToString();
+
             if (SoftwareSelectionList.SelectedItems == null) return;
             foreach (var selectedItem in SoftwareSelectionList.SelectedItems)
             {
                 if (selectedItem as ControlSystemSoftware is { } s)
                 {
-                    s.Download(folder[0].Path.ToString(),
+                    s.Download(downloadPath,
                         new CancellationToken());
                 }
             }


### PR DESCRIPTION
Hook up eventing for `ControlSystemSoftware.DownloadProgress` so the UX updates during download (including downloads skipped if file hash & size match)
Fix crash if the download folder dialog is cancelled